### PR TITLE
Add Astro-based CLI-style coffee log site - v2.1

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,0 +1,5 @@
+import { defineConfig } from "astro/config";
+
+export default defineConfig({
+  site: "https://codekiln.github.io/beans/"
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "beans",
+  "type": "module",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  },
+  "dependencies": {
+    "astro": "^4.16.4"
+  }
+}

--- a/src/components/BeanEntry.astro
+++ b/src/components/BeanEntry.astro
@@ -1,0 +1,84 @@
+---
+const { bean } = Astro.props;
+import TagRow from "./TagRow.astro";
+
+const command = `$ bean log ${bean.date} ${bean.beanKey}`;
+const cupEntries = Object.entries(bean.cup);
+const labelWidth = Math.max(
+  4,
+  ...cupEntries.map(([label]) => label.length)
+);
+const cupLines = [
+  "CUP",
+  ...cupEntries.map(([label, value]) => `${label.toUpperCase().padEnd(labelWidth)} ${value}`)
+];
+const innerWidth = Math.max(...cupLines.map((line) => line.length));
+const border = "─".repeat(innerWidth + 2);
+const asciiCup = [
+  `┌${border}┐`,
+  ...cupLines.map((line) => `│ ${line.padEnd(innerWidth)} │`),
+  `└${border}┘`
+].join("\n");
+---
+<article class="bean-entry" id={bean.slug} data-cli={command}>
+  <div class="ascii-block" aria-hidden="true">
+    <pre>{command}</pre>
+  </div>
+  <div class="bean-grid">
+    <div class="bean-main window">
+      <header>
+        <h2>{`BEAN ${bean.date} / ${bean.time}`}</h2>
+        <p class="ascii-block" aria-hidden="true">======================</p>
+      </header>
+      <TagRow tags={bean.tags} />
+      <section>
+        <h3 class="section-title">Coffee</h3>
+        <p>{bean.coffee.name}</p>
+        {bean.coffee.roast && <p>Roast: {bean.coffee.roast}</p>}
+        {bean.coffee.profile && <p>Profile: {bean.coffee.profile}</p>}
+        {bean.coffee.blend && <p>Blend: {bean.coffee.blend}</p>}
+      </section>
+      <section>
+        <h3 class="section-title">Brew</h3>
+        {bean.brew.brewer && <p>Brewer: {bean.brew.brewer}</p>}
+        {bean.brew.method && <p>Method: {bean.brew.method}</p>}
+      </section>
+      <section>
+        <h3 class="section-title">Observations</h3>
+        <ul>
+          {bean.observations.map((line) => (
+            <li>{line}</li>
+          ))}
+        </ul>
+      </section>
+    </div>
+    <aside class="bean-side" aria-label="Bean support panes">
+      <section class="window">
+        <table class="cup-table">
+          <caption>CUP</caption>
+          <tbody>
+            {cupEntries.map(([label, value]) => (
+              <tr>
+                <th scope="row">{label.toUpperCase()}</th>
+                <td>{value}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div class="ascii-block" aria-hidden="true">
+          <pre>{asciiCup}</pre>
+        </div>
+      </section>
+      <section class="window">
+        <h3 class="section-title">Gear references</h3>
+        <ul>
+          {bean.gear.map((item) => (
+            <li>
+              {item.label}: <a href={`/equipment/${item.slug}/`}>{item.value}</a>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </aside>
+  </div>
+</article>

--- a/src/components/TagRow.astro
+++ b/src/components/TagRow.astro
@@ -1,0 +1,13 @@
+---
+const { tags } = Astro.props;
+---
+<p class="tag-row" aria-label="Bean tags">
+  [
+  {tags.map((tag, index) => (
+    <Fragment>
+      <a class="tag-link" href={`/tags/${tag}/`}>{tag}</a>
+      {index < tags.length - 1 && " · "}
+    </Fragment>
+  ))}
+  ]
+</p>

--- a/src/data/beans.ts
+++ b/src/data/beans.ts
@@ -1,0 +1,120 @@
+export const beans = [
+  {
+    id: "2026-01-25-bean1",
+    beanKey: "bean1",
+    slug: "2026-01-25-bean1",
+    date: "2026-01-25",
+    time: "05:33",
+    title: "Reference cup, gentle balance",
+    tags: ["bitterness", "balance", "cooling"],
+    coffee: {
+      name: "Parable Coffee Co. — Mocha Java",
+      roast: "medium-dark",
+      profile: "dense · earthy berry · complete"
+    },
+    brew: {
+      brewer: "Hario Switch",
+      method: "Easy Immersion"
+    },
+    cup: {
+      dose: "15.9 g",
+      water: "250.3 g",
+      ratio: "~1 : 15.7",
+      grind: "(same as prior)",
+      release: "2:30",
+      total: "3:37"
+    },
+    observations: [
+      "Very even bed at finish.",
+      "Drawdown was clean and unremarkable — in a good way.",
+      "The cup opened sparkly.",
+      "Balanced acidity up front, nothing sharp.",
+      "As it cooled, nutty overtones came forward and stayed.",
+      "This felt like a reference cup.",
+      "Nothing exaggerated.",
+      "Everything in proportion."
+    ],
+    gear: [
+      { label: "grinder", value: "Timemore C5 ESP Pro", slug: "timemore-c5-esp-pro" },
+      { label: "brewer", value: "Hario Switch", slug: "hario-switch" }
+    ]
+  },
+  {
+    id: "2026-01-25-bean2",
+    beanKey: "bean2",
+    slug: "2026-01-25-bean2",
+    date: "2026-01-25",
+    time: "07:01",
+    title: "Mocha edge with synesthesia",
+    tags: ["mocha", "synesthesia", "weather"],
+    coffee: {
+      name: "Parable Coffee Co. — Mocha Java"
+    },
+    brew: {
+      brewer: "Hario Switch",
+      method: "Easy Immersion (minor workflow variations)"
+    },
+    cup: {
+      dose: "16.0 g",
+      water: "256.8 g",
+      ratio: "1 : 16",
+      grinder: "Timemore Chestnut",
+      setting: "1.8.1 (coarser)",
+      temp: "~90 °C",
+      release: "2:30",
+      total: "3:28"
+    },
+    observations: [
+      "Simulated RDT — beans contacted residual water in the mug.",
+      "First sip was mocha-forward.",
+      "A small, delicate burst right on the tongue.",
+      "Slightly hotter than the earlier cup.",
+      "Bitterness dropped into the range I like.",
+      "When I pressed my tongue to the roof of my mouth while swishing, the bitterness registered as a high-pitched tone — felt behind the eyes rather than on the tongue.",
+      "Overcast.",
+      "Snowstorm imminent but not yet started.",
+      "The cup felt alert, not heavy."
+    ],
+    gear: [
+      { label: "grinder", value: "Timemore Chestnut", slug: "timemore-chestnut" },
+      { label: "brewer", value: "Hario Switch", slug: "hario-switch" }
+    ]
+  },
+  {
+    id: "2026-01-24-bean2",
+    beanKey: "bean2",
+    slug: "2026-01-24-bean2",
+    date: "2026-01-24",
+    time: "06:15",
+    title: "Cold walk, music, grounded cup",
+    tags: ["cold", "walking", "music"],
+    coffee: {
+      name: "Parable Coffee Co.",
+      blend: "70% Sourdough · 30% Cold Winter"
+    },
+    brew: {
+      brewer: "Metal cone filter (no paper)"
+    },
+    cup: {
+      dose: "25.0 g",
+      water: "354.4 g",
+      time: "5:27"
+    },
+    observations: [
+      "Walking outside.",
+      "~10°F.",
+      "Pink and purple on the horizon.",
+      "Listening to the final minutes of Rachmaninoff Piano Concerto No. 3.",
+      "Eyes watered while drinking.",
+      "Then Bach: Partita No. 2 in C minor.",
+      "Wanted to sit down and play.",
+      "The cold sharpened everything.",
+      "The coffee felt grounding against the music — less about flavor notes, more about staying present in the body."
+    ],
+    gear: [
+      { label: "brewer", value: "Metal cone", slug: "metal-cone" }
+    ]
+  }
+];
+
+export const allTags = Array.from(new Set(beans.flatMap((bean) => bean.tags))).sort();

--- a/src/data/equipment.ts
+++ b/src/data/equipment.ts
@@ -1,0 +1,44 @@
+export const equipment = [
+  {
+    slug: "timemore-c5-esp-pro",
+    name: "Timemore C5 ESP Pro",
+    type: "grinder",
+    notes: [
+      "Hand grinder with repeatable stepped adjustments.",
+      "Reference point for daily brews and ratio experiments."
+    ],
+    related: ["timemore-chestnut"]
+  },
+  {
+    slug: "timemore-chestnut",
+    name: "Timemore Chestnut",
+    type: "grinder",
+    notes: [
+      "Older hand grinder with slightly broader particle spread.",
+      "Used here for coarser settings and tactile comparisons."
+    ],
+    related: ["timemore-c5-esp-pro"]
+  },
+  {
+    slug: "hario-switch",
+    name: "Hario Switch",
+    type: "brewer",
+    notes: [
+      "Immersion-capable dripper with clean release.",
+      "Primary brewer for switchable immersion experiments."
+    ],
+    related: []
+  },
+  {
+    slug: "metal-cone",
+    name: "Metal cone",
+    type: "brewer",
+    notes: [
+      "No paper filter, more oils and weight in the cup.",
+      "Useful for cold walks and outdoor brews."
+    ],
+    related: []
+  }
+];
+
+export const equipmentTypes = Array.from(new Set(equipment.map((item) => item.type))).sort();

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,0 +1,79 @@
+---
+const {
+  title = "Beans",
+  description = "A coffee log.",
+  initialCommand = "$ bean log 2026-01-25 bean1"
+} = Astro.props;
+---
+<!doctype html>
+<html lang="en" data-theme="auto">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content={description} />
+    <title>{title}</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&display=swap" />
+    <link rel="stylesheet" href="/styles/global.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="cli-float">
+      <div class="cli-command" data-cli-command aria-hidden="true">{initialCommand}</div>
+      <button class="theme-toggle" type="button" data-theme-toggle aria-label="Toggle theme">
+        <span aria-hidden="true">🫘</span>
+        <span class="theme-toggle-text">Theme</span>
+      </button>
+    </header>
+    <main id="main" class="page-shell">
+      <slot />
+    </main>
+    <footer class="page-shell footer">
+      <p>$ beans · a coffee log rendered as a lab notebook.</p>
+    </footer>
+    <script>
+      const root = document.documentElement;
+      const storedTheme = localStorage.getItem("beans-theme");
+      const media = window.matchMedia("(prefers-color-scheme: dark)");
+      const applyTheme = (value) => {
+        root.dataset.theme = value;
+      };
+      if (storedTheme) {
+        applyTheme(storedTheme);
+      } else {
+        applyTheme(media.matches ? "dark" : "light");
+      }
+      const toggle = document.querySelector("[data-theme-toggle]");
+      const toggleText = document.querySelector(".theme-toggle-text");
+      if (toggle) {
+        const updateLabel = () => {
+          if (toggleText) {
+            toggleText.textContent = root.dataset.theme === "dark" ? "Dark" : "Light";
+          }
+        };
+        updateLabel();
+        toggle.addEventListener("click", () => {
+          const next = root.dataset.theme === "dark" ? "light" : "dark";
+          applyTheme(next);
+          localStorage.setItem("beans-theme", next);
+          updateLabel();
+        });
+      }
+      const commandEl = document.querySelector("[data-cli-command]");
+      const entries = document.querySelectorAll("[data-cli]");
+      if (commandEl && entries.length) {
+        const observer = new IntersectionObserver(
+          (items) => {
+            const visible = items
+              .filter((item) => item.isIntersecting)
+              .sort((a, b) => b.intersectionRatio - a.intersectionRatio);
+            if (visible[0]) {
+              commandEl.textContent = visible[0].target.dataset.cli || commandEl.textContent;
+            }
+          },
+          { rootMargin: "-30% 0px -60% 0px", threshold: [0.3, 0.6, 1] }
+        );
+        entries.forEach((entry) => observer.observe(entry));
+      }
+    </script>
+  </body>
+</html>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,12 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+---
+<BaseLayout title="Not found · Beans" description="Page not found." initialCommand="$ bean missing">
+  <section class="hero">
+    <h1>404 — Bean not found</h1>
+    <p>The path is empty, but the log continues.</p>
+    <p>
+      <a href="/">[return to index]</a>
+    </p>
+  </section>
+</BaseLayout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,0 +1,28 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+---
+<BaseLayout title="About · Beans" description="About the beans log." initialCommand="$ bean about">
+  <section class="about-bean" aria-hidden="true">
+    <pre>
+        .-"""-.
+      .'  _   _ '.
+     /   (o) (o)  \
+    |     .-"-.    |
+    |    /     \   |
+     \   \     /  /
+      '._'---'_.'
+    </pre>
+  </section>
+  <section class="window">
+    <h1>About</h1>
+    <p>
+      Beans is a log of coffee, tools, attention, and mornings. Each bean marks a single
+      moment — a cup with a record of choices, weather, and how it landed.
+    </p>
+    <p>
+      The interface borrows from command-line notation, but the goal is readability and
+      clarity. Observations are written as plainly as possible, with structure that makes
+      change easy to notice.
+    </p>
+  </section>
+</BaseLayout>

--- a/src/pages/equipment/[slug].astro
+++ b/src/pages/equipment/[slug].astro
@@ -1,0 +1,45 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { equipment } from "../../data/equipment";
+
+export function getStaticPaths() {
+  return equipment.map((item) => ({ params: { slug: item.slug } }));
+}
+
+const { slug } = Astro.params;
+const item = equipment.find((entry) => entry.slug === slug);
+const related = equipment.filter((entry) => item?.related.includes(entry.slug));
+---
+<BaseLayout
+  title={`${item?.name ?? "Equipment"} · Beans`}
+  description={`Equipment reference for ${item?.name ?? "gear"}.`}
+  initialCommand={`$ bean ${item?.type ?? "equipment"} ${item?.slug ?? ""}`.trim()}
+>
+  <section class="hero">
+    <h1>{item?.name}</h1>
+    <p>Namespace: {item?.type}</p>
+    <p>
+      <a href="/equipment/">[back to equipment]</a>
+    </p>
+  </section>
+  <section class="window">
+    <h2 class="section-title">Notes</h2>
+    <ul>
+      {item?.notes.map((note) => (
+        <li>{note}</li>
+      ))}
+    </ul>
+  </section>
+  {related.length > 0 && (
+    <section class="window">
+      <h2 class="section-title">Related</h2>
+      <ul>
+        {related.map((entry) => (
+          <li>
+            <a href={`/equipment/${entry.slug}/`}>[{entry.name}]</a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )}
+</BaseLayout>

--- a/src/pages/equipment/index.astro
+++ b/src/pages/equipment/index.astro
@@ -1,0 +1,29 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { equipment, equipmentTypes } from "../../data/equipment";
+
+const grouped = equipmentTypes.map((type) => ({
+  type,
+  items: equipment.filter((item) => item.type === type)
+}));
+---
+<BaseLayout title="Equipment · Beans" description="Coffee gear references." initialCommand="$ bean equipment">
+  <section class="hero">
+    <h1>Equipment namespaces</h1>
+    <p>Grinders, brewers, and tools referenced by beans.</p>
+  </section>
+  {grouped.map((group) => (
+    <section class="window" aria-labelledby={`equipment-${group.type}`}>
+      <h2 id={`equipment-${group.type}`} class="section-title">
+        {group.type}
+      </h2>
+      <ul class="table-list">
+        {group.items.map((item) => (
+          <li>
+            <a href={`/equipment/${item.slug}/`}>[{item.name}]</a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  ))}
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,0 +1,22 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import BeanEntry from "../components/BeanEntry.astro";
+import { beans } from "../data/beans";
+
+const initialCommand = `$ bean log ${beans[0].date} ${beans[0].beanKey}`;
+---
+<BaseLayout title="Beans" description="A CLI-inspired coffee log." initialCommand={initialCommand}>
+  <section class="hero">
+    <h1>Beans: a coffee log in CLI form.</h1>
+    <p>
+      A knowledge garden for cups, tools, and attention. The command line is a metaphor; the
+      writing is the record.
+    </p>
+    <p>
+      <a href="/about/">[about]</a> · <a href="/equipment/">[equipment]</a>
+    </p>
+  </section>
+  {beans.map((bean) => (
+    <BeanEntry bean={bean} />
+  ))}
+</BaseLayout>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,0 +1,24 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BeanEntry from "../../components/BeanEntry.astro";
+import { beans, allTags } from "../../data/beans";
+
+export function getStaticPaths() {
+  return allTags.map((tag) => ({ params: { tag } }));
+}
+
+const { tag } = Astro.params;
+const taggedBeans = beans.filter((bean) => bean.tags.includes(tag));
+---
+<BaseLayout title={`Tag: ${tag} · Beans`} description={`Beans tagged with ${tag}.`} initialCommand={`$ bean tag ${tag}`}>
+  <section class="hero">
+    <h1>Tag: {tag}</h1>
+    <p>{taggedBeans.length} bean(s) match this tag.</p>
+    <p>
+      <a href="/">[back to all beans]</a>
+    </p>
+  </section>
+  {taggedBeans.map((bean) => (
+    <BeanEntry bean={bean} />
+  ))}
+</BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,261 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f6f2ec;
+  --bg-elevated: #fbf7f1;
+  --text: #1e1a15;
+  --muted: #5a5046;
+  --border: #7a6a58;
+  --accent: #7a3f00;
+  --accent-hover: #5b2d00;
+  --focus: #c05600;
+  --shadow: rgba(30, 26, 21, 0.1);
+}
+
+:root[data-theme="dark"] {
+  --bg: #14110f;
+  --bg-elevated: #1d1916;
+  --text: #f2ede6;
+  --muted: #c1b7ab;
+  --border: #b5a08a;
+  --accent: #f0c68a;
+  --accent-hover: #f6d6a8;
+  --focus: #f5b66a;
+  --shadow: rgba(0, 0, 0, 0.4);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+main {
+  display: block;
+}
+
+img,
+svg {
+  max-width: 100%;
+  height: auto;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px;
+}
+
+a:hover,
+a:focus-visible {
+  color: var(--accent-hover);
+}
+
+a:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.skip-link:focus {
+  left: 1rem;
+  top: 1rem;
+  width: auto;
+  height: auto;
+  padding: 0.5rem 1rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  z-index: 1000;
+}
+
+.page-shell {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 5.5rem 1.5rem 4rem;
+}
+
+.cli-float {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: color-mix(in srgb, var(--bg) 85%, transparent);
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid var(--border);
+  padding: 0.75rem 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.cli-command {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.theme-toggle {
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--text);
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  cursor: pointer;
+  font-size: 1rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  box-shadow: 0 1px 2px var(--shadow);
+}
+
+.theme-toggle span {
+  font-size: 1.2rem;
+}
+
+.hero {
+  margin-bottom: 3rem;
+}
+
+.hero h1 {
+  font-size: clamp(1.8rem, 2.4vw, 2.6rem);
+  margin: 0 0 1rem;
+}
+
+.hero p {
+  max-width: 60ch;
+  color: var(--muted);
+}
+
+.window {
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  padding: 1.25rem;
+  box-shadow: 0 2px 8px var(--shadow);
+}
+
+.bean-entry {
+  margin-bottom: 3rem;
+}
+
+.bean-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 1.5rem;
+}
+
+.bean-main {
+  grid-column: 1 / 2;
+}
+
+.bean-side {
+  grid-column: 2 / 3;
+  display: grid;
+  gap: 1rem;
+  align-content: start;
+}
+
+@media (max-width: 900px) {
+  .bean-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .bean-side {
+    grid-column: 1 / -1;
+  }
+}
+
+.section-title {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.9rem;
+  margin: 2rem 0 0.75rem;
+}
+
+.tag-link {
+  font-size: 0.95rem;
+  padding: 0 0.1rem;
+}
+
+.tag-row {
+  margin: 0.5rem 0 1rem;
+}
+
+.cup-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.cup-table caption {
+  text-align: left;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.cup-table th,
+.cup-table td {
+  border: 1px solid var(--border);
+  padding: 0.4rem 0.6rem;
+  text-align: left;
+}
+
+.cup-table th {
+  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  width: 45%;
+}
+
+.ascii-block {
+  font-size: 0.85rem;
+  color: var(--muted);
+  margin: 0.5rem 0 1rem;
+}
+
+.ascii-block pre {
+  margin: 0;
+}
+
+.footer {
+  margin-top: 4rem;
+  padding-top: 2rem;
+  border-top: 1px dashed var(--border);
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.table-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.about-bean {
+  text-align: center;
+  font-size: 1.1rem;
+  margin-bottom: 2rem;
+  color: var(--muted);
+}
+
+.about-bean pre {
+  display: inline-block;
+  padding: 1rem 1.5rem;
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "astro/tsconfigs/strict"
+}


### PR DESCRIPTION
### Motivation
- Provide a static, accessible scaffold for a personal coffee knowledge garden that uses a CLI metaphor for presentation while keeping semantic HTML and WCAG-conscious styling.
- Support the core content model (beans → cups), tag-based navigation, and equipment namespaces so content can be authored as structured data and rendered simply.

### Description
- Add an Astro site scaffold with `package.json`, `astro.config.mjs`, and `tsconfig.json` and a base layout `src/layouts/BaseLayout.astro` that implements a sticky CLI command, theme toggle, and intersection-based updates of the command display.
- Add components and data: `src/components/BeanEntry.astro` (bean renderer with dynamic ASCII cup generator), `src/components/TagRow.astro`, and data files `src/data/beans.ts` and `src/data/equipment.ts` to drive pages.
- Add pages for index, about, 404, tag listing, equipment index and equipment detail under `src/pages/` and a global stylesheet `src/styles/global.css` implementing the CLI aesthetic, responsive two-column layout, and accessibility-focused color tokens and focus styles.

### Testing
- Ran `npm install` to fetch dependencies but the install failed with a `403 Forbidden` when fetching `astro`, preventing running `astro dev` or `astro build`.
- No automated tests are included in the scaffold and no build/dev server was able to be started due to the dependency fetch failure.
- Basic file-level verification was performed by creating and listing the new files in the repo to ensure the site structure and exports are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976b6c7c9cc8320837dcbfd8466c816)