### PR TITLE
Create initial CLI-inspired coffee log site v2.2

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>About — Beans</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="sticky-command" aria-hidden="true">
+      <div class="prompt">$ bean about</div>
+    </header>
+
+    <button class="theme-toggle" type="button" aria-label="Toggle theme">
+      <span aria-hidden="true">🫘</span>
+    </button>
+
+    <main id="main">
+      <section class="window" aria-labelledby="about-title">
+        <h1 id="about-title">About</h1>
+        <pre class="ascii-box bean-art" aria-hidden="true">
+                 .-''''-.
+              .-'        '-.
+            .'              '.
+           /   .--.  .--.     \
+          /   /    \/    \     \
+          |  |  .-.  .-.  |    |
+          |  | (   )(   ) |    |
+          |  |  '-'  '-'  |    |
+          \   \    /\    /    /
+           \   '._/  \_.'    /
+            '.            .'
+              '-.______.-'
+        </pre>
+        <p>
+          Beans is a log of coffee, tools, attention, and mornings. It is a
+          command-line metaphor rendered softly in the browser: structured data,
+          quiet observations, and the slow build of a personal knowledge garden.
+        </p>
+        <p>
+          Each bean is a moment. Most beans hold one cup, sometimes two when the
+          changes are meaningfully related. The interface stays technical and
+          readable, because the details deserve calm light.
+        </p>
+        <p>
+          <a href="/">Back to the log</a>
+        </p>
+      </section>
+    </main>
+
+    <script src="/script.js"></script>
+  </body>
+</html>

--- a/equipment/brewers/hario-switch/index.html
+++ b/equipment/brewers/hario-switch/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Hario Switch — Beans</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="sticky-command" aria-hidden="true">
+      <div class="prompt">$ bean brewer hario-switch</div>
+    </header>
+
+    <button class="theme-toggle" type="button" aria-label="Toggle theme">
+      <span aria-hidden="true">🫘</span>
+    </button>
+
+    <main id="main">
+      <section class="window" aria-labelledby="brewer-title">
+        <h1 id="brewer-title">Hario Switch</h1>
+        <p>
+          Glass dripper with a silicone valve. The switch toggles between
+          immersion and drawdown, making timing and release the primary
+          variables to record.
+        </p>
+        <pre class="ascii-box" aria-label="Flow note">
+Flow profile
+------------
+Immersion → release
+Clean drawdown
+Minimal agitation
+        </pre>
+        <p>
+          <a href="/equipment/brewers/">Back to brewers</a>
+        </p>
+      </section>
+    </main>
+
+    <script src="/script.js"></script>
+  </body>
+</html>

--- a/equipment/brewers/index.html
+++ b/equipment/brewers/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Brewers — Beans</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="sticky-command" aria-hidden="true">
+      <div class="prompt">$ bean equipment brewer</div>
+    </header>
+
+    <button class="theme-toggle" type="button" aria-label="Toggle theme">
+      <span aria-hidden="true">🫘</span>
+    </button>
+
+    <main id="main">
+      <section class="window" aria-labelledby="brewers-title">
+        <h1 id="brewers-title">Brewers</h1>
+        <p>
+          Brewer pages document technique, flow profiles, and how immersion
+          tools shape texture.
+        </p>
+        <ul>
+          <li>
+            <a href="/equipment/brewers/hario-switch/">Hario Switch</a>
+          </li>
+        </ul>
+        <p>
+          <a href="/equipment/">Back to equipment</a>
+        </p>
+      </section>
+    </main>
+
+    <script src="/script.js"></script>
+  </body>
+</html>

--- a/equipment/grinders/index.html
+++ b/equipment/grinders/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Grinders — Beans</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="sticky-command" aria-hidden="true">
+      <div class="prompt">$ bean equipment grinder</div>
+    </header>
+
+    <button class="theme-toggle" type="button" aria-label="Toggle theme">
+      <span aria-hidden="true">🫘</span>
+    </button>
+
+    <main id="main">
+      <section class="window" aria-labelledby="grinders-title">
+        <h1 id="grinders-title">Grinders</h1>
+        <p>
+          Grinder pages track burr geometry, adjustment language, and how each
+          tool shapes the cup.
+        </p>
+        <ul>
+          <li>
+            <a href="/equipment/grinders/timemore-c5-esp-pro/"
+              >Timemore C5 ESP Pro</a
+            >
+          </li>
+        </ul>
+        <p>
+          <a href="/equipment/">Back to equipment</a>
+        </p>
+      </section>
+    </main>
+
+    <script src="/script.js"></script>
+  </body>
+</html>

--- a/equipment/grinders/timemore-c5-esp-pro/index.html
+++ b/equipment/grinders/timemore-c5-esp-pro/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Timemore C5 ESP Pro — Beans</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="sticky-command" aria-hidden="true">
+      <div class="prompt">$ bean grinder timemore-c5-esp-pro</div>
+    </header>
+
+    <button class="theme-toggle" type="button" aria-label="Toggle theme">
+      <span aria-hidden="true">🫘</span>
+    </button>
+
+    <main id="main">
+      <section class="window" aria-labelledby="grinder-title">
+        <h1 id="grinder-title">Timemore C5 ESP Pro</h1>
+        <p>
+          Compact hand grinder with a stepped adjustment collar and a narrow
+          espresso-to-filter range. The click language is stable enough to log
+          both espresso and immersion.
+        </p>
+        <pre class="ascii-box" aria-label="Adjustment sketch">
+Adjustment map
+--------------
+0.6.0  espresso edge
+1.0.0  moka / aeropress
+1.6.0  immersion baseline
+2.0.0  coarse filter
+        </pre>
+        <p>
+          Referenced by beans where grind setting is the primary variable.
+        </p>
+        <p>
+          <a href="/equipment/grinders/">Back to grinders</a>
+        </p>
+      </section>
+    </main>
+
+    <script src="/script.js"></script>
+  </body>
+</html>

--- a/equipment/index.html
+++ b/equipment/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Equipment — Beans</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="sticky-command" aria-hidden="true">
+      <div class="prompt">$ bean equipment list</div>
+    </header>
+
+    <button class="theme-toggle" type="button" aria-label="Toggle theme">
+      <span aria-hidden="true">🫘</span>
+    </button>
+
+    <main id="main">
+      <section class="window" aria-labelledby="equipment-title">
+        <h1 id="equipment-title">Equipment</h1>
+        <p>Namespaces keep gear discoverable and cross-referenced.</p>
+        <ul>
+          <li>
+            <a href="/equipment/grinders/">grinder</a> — hand grinders and burrs
+          </li>
+          <li>
+            <a href="/equipment/brewers/">brewer</a> — drippers and immersion
+          </li>
+        </ul>
+        <p>
+          <a href="/">Back to the log</a>
+        </p>
+      </section>
+    </main>
+
+    <script src="/script.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Beans — Coffee Log</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="sticky-command" aria-hidden="true">
+      <div class="prompt">$ bean log 2026-01-25 bean2</div>
+    </header>
+
+    <button class="theme-toggle" type="button" aria-label="Toggle theme">
+      <span aria-hidden="true">🫘</span>
+    </button>
+
+    <main id="main">
+      <section class="intro window" aria-labelledby="intro-title">
+        <h1 id="intro-title">Beans</h1>
+        <p>
+          A CLI-inspired coffee log: one bean at a time, two cups a day,
+          structured data alongside quiet observations.
+        </p>
+        <p class="meta">
+          Default theme follows system preference. Manual toggle is the bean.
+        </p>
+      </section>
+
+      <section class="tag-filter window" aria-live="polite">
+        <h2>Tags</h2>
+        <p id="tag-status">Showing all beans.</p>
+        <p>
+          Choose a tag to filter. Clear the filter with
+          <a href="#">[ all beans ]</a>.
+        </p>
+      </section>
+
+      <section class="bean-list" aria-label="Bean log">
+        <article
+          class="bean"
+          id="bean-2026-01-25-1"
+          data-command="$ bean log 2026-01-25 bean1"
+          data-tags="bitterness,balance,cooling"
+        >
+          <header class="bean-header">
+            <p class="bean-command">$ bean log 2026-01-25 bean1</p>
+            <h2>BEAN 2026-01-25 / 05:33</h2>
+            <p class="tags">
+              <a class="tag" href="#tag-bitterness">[ bitterness ]</a>
+              <a class="tag" href="#tag-balance">[ balance ]</a>
+              <a class="tag" href="#tag-cooling">[ cooling ]</a>
+            </p>
+          </header>
+
+          <div class="window-grid">
+            <section class="window narrative" aria-labelledby="bean1-notes">
+              <h3 id="bean1-notes">Observations</h3>
+              <p>
+                Very even bed at finish. Drawdown was clean and unremarkable —
+                in a good way.
+              </p>
+              <p>
+                The cup opened sparkly. Balanced acidity up front, nothing sharp.
+                As it cooled, nutty overtones came forward and stayed.
+              </p>
+              <p>
+                This felt like a reference cup. Nothing exaggerated. Everything
+                in proportion.
+              </p>
+            </section>
+
+            <aside class="window support" aria-label="Coffee and brew data">
+              <section>
+                <h3>Coffee</h3>
+                <p>Parable Coffee Co. — Mocha Java</p>
+                <p>Roast: medium-dark</p>
+                <p>Profile: dense · earthy berry · complete</p>
+              </section>
+              <section>
+                <h3>Brew</h3>
+                <p>
+                  Brewer:
+                  <a href="/equipment/brewers/hario-switch/">Hario Switch</a>
+                </p>
+                <p>Method: Easy Immersion</p>
+                <pre class="ascii-box" aria-label="Cup stats">
+┌──────────────────────────┐
+│ CUP                      │
+│ DOSE     15.9 g           │
+│ WATER    250.3 g          │
+│ RATIO    ~1 : 15.7        │
+│ GRIND    (same as prior)  │
+│ RELEASE  2:30             │
+│ TOTAL    3:37             │
+└──────────────────────────┘
+                </pre>
+              </section>
+            </aside>
+          </div>
+        </article>
+
+        <article
+          class="bean"
+          id="bean-2026-01-25-2"
+          data-command="$ bean log 2026-01-25 bean2"
+          data-tags="mocha,synesthesia,weather"
+        >
+          <header class="bean-header">
+            <p class="bean-command">$ bean log 2026-01-25 bean2</p>
+            <h2>BEAN 2026-01-25 / 07:01</h2>
+            <p class="tags">
+              <a class="tag" href="#tag-mocha">[ mocha ]</a>
+              <a class="tag" href="#tag-synesthesia">[ synesthesia ]</a>
+              <a class="tag" href="#tag-weather">[ weather ]</a>
+            </p>
+          </header>
+
+          <div class="window-grid">
+            <section class="window narrative" aria-labelledby="bean2-notes">
+              <h3 id="bean2-notes">Notes</h3>
+              <p>
+                Simulated RDT — beans contacted residual water in the mug.
+              </p>
+              <p>
+                First sip was mocha-forward. A small, delicate burst right on the
+                tongue. Slightly hotter than the earlier cup.
+              </p>
+              <p>
+                Bitterness dropped into the range I like. When I pressed my
+                tongue to the roof of my mouth while swishing, the bitterness
+                registered as a high-pitched tone — felt behind the eyes rather
+                than on the tongue.
+              </p>
+              <p>
+                Overcast. Snowstorm imminent but not yet started. The cup felt
+                alert, not heavy.
+              </p>
+            </section>
+
+            <aside class="window support" aria-label="Coffee and brew data">
+              <section>
+                <h3>Coffee</h3>
+                <p>Parable Coffee Co. — Mocha Java</p>
+              </section>
+              <section>
+                <h3>Brew</h3>
+                <p>
+                  Brewer:
+                  <a href="/equipment/brewers/hario-switch/">Hario Switch</a>
+                </p>
+                <p>Method: Easy Immersion (minor workflow variations)</p>
+                <p>
+                  Grinder:
+                  <a href="/equipment/grinders/timemore-c5-esp-pro/"
+                    >Timemore C5 ESP Pro</a
+                  >
+                </p>
+                <pre class="ascii-box" aria-label="Cup stats">
+┌──────────────────────────┐
+│ CUP                      │
+│ DOSE     16.0 g           │
+│ WATER    256.8 g          │
+│ RATIO    1 : 16           │
+│ GRINDER  Timemore C5 ESP  │
+│ SETTING  1.8.1 (coarser)  │
+│ TEMP     ~90 °C           │
+│ RELEASE  2:30             │
+│ TOTAL    3:28             │
+└──────────────────────────┘
+                </pre>
+              </section>
+            </aside>
+          </div>
+        </article>
+
+        <article
+          class="bean"
+          id="bean-2026-01-24-2"
+          data-command="$ bean log 2026-01-24 bean2"
+          data-tags="cold,walking,music"
+        >
+          <header class="bean-header">
+            <p class="bean-command">$ bean log 2026-01-24 bean2</p>
+            <h2>BEAN 2026-01-24 / 06:15</h2>
+            <p class="tags">
+              <a class="tag" href="#tag-cold">[ cold ]</a>
+              <a class="tag" href="#tag-walking">[ walking ]</a>
+              <a class="tag" href="#tag-music">[ music ]</a>
+            </p>
+          </header>
+
+          <div class="window-grid">
+            <section class="window narrative" aria-labelledby="bean3-notes">
+              <h3 id="bean3-notes">Context</h3>
+              <p>Walking outside. ~10°F. Pink and purple on the horizon.</p>
+              <p>
+                Listening to the final minutes of Rachmaninoff Piano Concerto
+                No. 3. Eyes watered while drinking. Then Bach: Partita No. 2 in
+                C minor. Wanted to sit down and play.
+              </p>
+              <h3>Taste</h3>
+              <p>
+                The cold sharpened everything. The coffee felt grounding against
+                the music — less about flavor notes, more about staying present
+                in the body.
+              </p>
+            </section>
+
+            <aside class="window support" aria-label="Coffee and brew data">
+              <section>
+                <h3>Coffee</h3>
+                <p>Parable Coffee Co.</p>
+                <p>Blend: 70% Sourdough · 30% Cold Winter</p>
+              </section>
+              <section>
+                <h3>Brew</h3>
+                <p>Metal cone filter (no paper)</p>
+                <pre class="ascii-box" aria-label="Cup stats">
+┌──────────────────────────┐
+│ CUP                      │
+│ DOSE     25.0 g           │
+│ WATER    354.4 g          │
+│ TIME     5:27             │
+└──────────────────────────┘
+                </pre>
+              </section>
+            </aside>
+          </div>
+        </article>
+      </section>
+    </main>
+
+    <footer class="site-footer window">
+      <p>
+        <a href="/about/">About</a> ·
+        <a href="/equipment/">Equipment</a> ·
+        <a href="mailto:hello@codekiln.test">Contact</a>
+      </p>
+    </footer>
+
+    <script src="/script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,64 @@
+const commandBar = document.querySelector('.sticky-command .prompt');
+const beans = Array.from(document.querySelectorAll('.bean'));
+const toggle = document.querySelector('.theme-toggle');
+const tagStatus = document.querySelector('#tag-status');
+
+const storedTheme = localStorage.getItem('beans-theme');
+if (storedTheme) {
+  document.documentElement.setAttribute('data-theme', storedTheme);
+}
+
+toggle?.addEventListener('click', () => {
+  const current = document.documentElement.getAttribute('data-theme');
+  const next = current === 'dark' ? 'light' : 'dark';
+  document.documentElement.setAttribute('data-theme', next);
+  localStorage.setItem('beans-theme', next);
+});
+
+const observer = new IntersectionObserver(
+  (entries) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        const command = entry.target.getAttribute('data-command');
+        if (command && commandBar) {
+          commandBar.textContent = command;
+        }
+      }
+    });
+  },
+  {
+    rootMargin: '-40% 0px -50% 0px',
+    threshold: 0.1,
+  }
+);
+
+beans.forEach((bean) => observer.observe(bean));
+
+const updateTagFilter = () => {
+  const hash = window.location.hash;
+  const tagMatch = hash.match(/^#tag-(.+)$/);
+  if (!tagMatch) {
+    beans.forEach((bean) => bean.classList.remove('is-hidden'));
+    if (tagStatus) {
+      tagStatus.textContent = 'Showing all beans.';
+    }
+    return;
+  }
+
+  const tag = decodeURIComponent(tagMatch[1]);
+  beans.forEach((bean) => {
+    const tags = bean.dataset.tags?.split(',') ?? [];
+    if (tags.includes(tag)) {
+      bean.classList.remove('is-hidden');
+    } else {
+      bean.classList.add('is-hidden');
+    }
+  });
+
+  if (tagStatus) {
+    tagStatus.textContent = `Filtering by tag: ${tag}`;
+  }
+};
+
+window.addEventListener('hashchange', updateTagFilter);
+updateTagFilter();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,213 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f6f1e8;
+  --bg-alt: #ffffff;
+  --text: #1f1b16;
+  --muted: #4a4036;
+  --border: #2f2720;
+  --accent: #6b3d00;
+  --tag-bg: #ede5da;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0f0d0b;
+    --bg-alt: #191612;
+    --text: #f2e9dd;
+    --muted: #d0c4b4;
+    --border: #c2b4a0;
+    --accent: #f4c18a;
+    --tag-bg: #241e18;
+  }
+}
+
+[data-theme="light"] {
+  --bg: #f6f1e8;
+  --bg-alt: #ffffff;
+  --text: #1f1b16;
+  --muted: #4a4036;
+  --border: #2f2720;
+  --accent: #6b3d00;
+  --tag-bg: #ede5da;
+}
+
+[data-theme="dark"] {
+  --bg: #0f0d0b;
+  --bg-alt: #191612;
+  --text: #f2e9dd;
+  --muted: #d0c4b4;
+  --border: #c2b4a0;
+  --accent: #f4c18a;
+  --tag-bg: #241e18;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "SFMono-Regular", "Menlo", "Consolas", "Liberation Mono",
+    monospace;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 120px 20px 60px;
+  display: grid;
+  gap: 28px;
+}
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: 10px;
+  background: var(--accent);
+  color: var(--bg);
+  padding: 8px 12px;
+  border-radius: 6px;
+  text-decoration: none;
+}
+
+.skip-link:focus {
+  left: 12px;
+}
+
+.sticky-command {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--bg);
+  border-bottom: 2px solid var(--border);
+  padding: 12px 20px;
+}
+
+.prompt {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.theme-toggle {
+  position: fixed;
+  right: 20px;
+  top: 70px;
+  z-index: 20;
+  border: 2px solid var(--border);
+  background: var(--bg-alt);
+  border-radius: 999px;
+  padding: 10px 14px;
+  cursor: pointer;
+  font-size: 1.1rem;
+}
+
+.theme-toggle:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.window {
+  border: 2px solid var(--border);
+  padding: 20px;
+  background: var(--bg-alt);
+  box-shadow: 6px 6px 0 var(--border);
+}
+
+.intro h1 {
+  margin-top: 0;
+  font-size: 2rem;
+}
+
+.meta {
+  color: var(--muted);
+}
+
+.bean-header h2 {
+  margin: 0.2rem 0 0.6rem;
+}
+
+.bean-command {
+  margin: 0;
+  color: var(--muted);
+}
+
+.tags {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tag {
+  padding: 2px 6px;
+  border: 1px solid var(--border);
+  background: var(--tag-bg);
+  text-decoration: underline;
+}
+
+.tag:focus-visible,
+.site-footer a:focus-visible,
+.window a:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 2px;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+}
+
+.window-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.narrative h3,
+.support h3 {
+  margin-top: 0;
+}
+
+.ascii-box {
+  margin: 12px 0 0;
+  padding: 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  overflow-x: auto;
+  font-size: 0.95rem;
+}
+
+.bean {
+  display: grid;
+  gap: 16px;
+}
+
+.is-hidden {
+  display: none;
+}
+
+.site-footer {
+  margin: 40px auto 80px;
+  max-width: 1100px;
+  text-align: center;
+}
+
+.site-footer p {
+  margin: 0;
+}
+
+@media (max-width: 700px) {
+  main {
+    padding-top: 100px;
+  }
+
+  .theme-toggle {
+    right: 12px;
+    top: 62px;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a static, accessible, CLI-styled personal coffee log that models the "bean"/"cup" content model and is easy to extend. 
- Surface structured brew data alongside quiet narrative observations while preserving semantic HTML and keyboard accessibility. 
- Support light/dark themes and a simple, static-site friendly interaction model for filtering and presentational CLI context. 

### Description
- Add the main static homepage `index.html` with sample beans, tag links, accessible markup, and ASCII-style cup stats rendered inside semantic elements. 
- Add `styles.css` with monospace typography, light/dark theme variables, WCAG-conscious color choices, focus outlines, and a tiled window-like layout. 
- Add `script.js` implementing the theme toggle, sticky command update via `IntersectionObserver`, and hashtag-based tag filtering. 
- Create `about/` and `equipment/` namespaces plus initial equipment pages under `equipment/grinders/timemore-c5-esp-pro/` and `equipment/brewers/hario-switch/`. 

### Testing
- Launched a local static server with `python -m http.server 8000` and verified the site served without errors. 
- Captured a full-page screenshot using Playwright which produced `artifacts/beans-home.png`, confirming the homepage renders as expected. 
- No automated unit tests or accessibility audits were added for this change (static HTML/CSS/JS only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976b6c7c9cc8320837dcbfd8466c816)