### PR TITLE
Add January 27, 06:13 coffee log entry

### DIFF
--- a/src/data/beans.ts
+++ b/src/data/beans.ts
@@ -1,5 +1,57 @@
 export const beans = [
   {
+    id: "2026-01-27-bean1",
+    beanKey: "bean1",
+    slug: "2026-01-27-bean1",
+    date: "2026-01-27",
+    time: "06:13",
+    title: "Unicorn mug, focused immersion",
+    tags: ["focus", "cold", "unicorn", "video"],
+    coffee: {
+      roaster: { name: "Parable Coffee Co.", slug: "parable-coffee-co" },
+      roast: { name: "Mocha Java", slug: "mocha-java" },
+      roastLevel: "medium-dark",
+      profile: "dense · earthy berry · complete"
+    },
+    brew: {
+      brewer: { name: "Hario Switch", slug: "hario-switch" },
+      method: "Easy Immersion (closed switch)",
+      recipe: { name: "Easy Immersion", slug: "easy-immersion" },
+      notes: [
+        "RDT-style droplet in the dosing cup to reduce static.",
+        "Forgot to pre-wet the filter before dosing; moved grounds aside to pre-wet.",
+        "Patagonia MiiR mug used to preheat the cone.",
+        "Fast clockwise pour to 210 g, then topped to 255.9 g."
+      ]
+    },
+    brewDetails: {
+      dose: "16.1 g (16.0 g ground)",
+      water: "255.9 g",
+      ratio: "1 : 16",
+      grinder: { name: "Timemore C5 ESP Pro", slug: "timemore-c5-esp-pro" },
+      grind: "0.8.3",
+      temp: "~90 °C",
+      release: "2:32",
+      total: "3:24"
+    },
+    observations: [
+      "Started with a video about a new macOS tiling window manager, then shut it off to focus.",
+      "Mocha Java smelled dense and earthy right out of the bag.",
+      "Unicorn mug got a deep two-sniff approval.",
+      "Brew water was steaming with bubbles forming, not yet rolling.",
+      "Drawdown finished faster than usual; only a few dribbles remained.",
+      "First sip: nutty, complex, earthy, with a balanced, dense bitterness.",
+      "About six degrees outside; winter cold sharpened attention."
+    ],
+    gear: [
+      {
+        label: "scale",
+        value: "Maestri House Mini Coffee Scale",
+        slug: "maestri-house-mini-scale"
+      }
+    ]
+  },
+  {
     id: "2026-01-26-bean2",
     beanKey: "bean2",
     slug: "2026-01-26-bean2",


### PR DESCRIPTION
### Motivation
- Record the morning cup from 2026-01-27 (06:13) with brew workflow notes, sensory observations, and gear so the log includes this focused Hario Switch immersion brew of Parable Coffee Co. Mocha Java.

### Description
- Add a new bean object to `src/data/beans.ts` with `id: "2026-01-27-bean1"` that includes metadata (`date`, `time`, `title`, `tags`), `coffee` details (roaster, roast, roastLevel, profile), `brew` notes, `brewDetails` (dose, water, ratio, grinder, grind, temp, release, total), `observations`, and `gear`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978a218ce108320a3e2d434b07e850a)