### PR TITLE
Add bean titles to entry headers

### DIFF
--- a/src/components/BeanEntry.astro
+++ b/src/components/BeanEntry.astro
@@ -75,6 +75,7 @@ const gearItems = [
     <div class="bean-main window">
       <header>
         <h2>{`BEAN ${bean.date} / ${bean.time}`}</h2>
+        <p class="bean-title">{bean.title}</p>
         <p class="ascii-block" aria-hidden="true">======================</p>
       </header>
       <section>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -209,6 +209,12 @@ button:focus-visible {
   grid-column: 1 / 2;
 }
 
+.bean-title {
+  margin: 0.35rem 0 0.65rem;
+  font-size: 1.1rem;
+  color: var(--muted);
+}
+
 .bean-side {
   grid-column: 2 / 3;
   display: grid;


### PR DESCRIPTION
### Motivation
- Surface each bean's `title` within the entry header so posts show a human-friendly title in-context rather than only in page metadata.

### Description
- Rendered the title in the entry header by adding `<p class="bean-title">{bean.title}</p>` to `src/components/BeanEntry.astro`.
- Added `.bean-title` rules to `src/styles/global.css` to style placement, sizing, and muted color.

### Testing
- Started the dev server with `npm run dev` and confirmed the site served the `/beans/` base path successfully (server started and served pages). (succeeded)
- Captured a visual check using a Playwright script that loaded `http://127.0.0.1:4321/beans/` and saved a screenshot artifact, confirming the title appears in the entry UI. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979d734c1f483209326edb12bcabcca)