### PR TITLE
Add preview instruction to RuleSync rules

### DIFF
--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -10,6 +10,7 @@ Beans is a CLI-inspired coffee log built with Astro. The site content lives in `
 ## General Guidelines
 
 - Always generate previews using the `/beans/` base prefix (for example: `/beans/log/<slug>`).
+- When a user requests changes, load `AGENTS.md` first and provide a preview in ChatGPT Codex.
 - Follow existing project conventions and patterns; mirror nearby code style when editing files.
 - Prefer small, focused changes that keep the CLI-inspired tone of the site intact.
 - Use the existing utilities (such as `withBase`) for building paths and links.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,6 +5,7 @@ Beans is a CLI-inspired coffee log built with Astro. The site content lives in `
 ## General Guidelines
 
 - Always generate previews using the `/beans/` base prefix (for example: `/beans/log/<slug>`).
+- When a user requests changes, load `AGENTS.md` first and provide a preview in ChatGPT Codex.
 - Follow existing project conventions and patterns; mirror nearby code style when editing files.
 - Prefer small, focused changes that keep the CLI-inspired tone of the site intact.
 - Use the existing utilities (such as `withBase`) for building paths and links.

--- a/.rulesync/rules/overview.md
+++ b/.rulesync/rules/overview.md
@@ -12,6 +12,7 @@ Beans is a CLI-inspired coffee log built with Astro. The site content lives in `
 ## General Guidelines
 
 - Always generate previews using the `/beans/` base prefix (for example: `/beans/log/<slug>`).
+- When a user requests changes, load `AGENTS.md` first and provide a preview in ChatGPT Codex.
 - Follow existing project conventions and patterns; mirror nearby code style when editing files.
 - Prefer small, focused changes that keep the CLI-inspired tone of the site intact.
 - Use the existing utilities (such as `withBase`) for building paths and links.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Beans is a CLI-inspired coffee log built with Astro. The site content lives in `
 ## General Guidelines
 
 - Always generate previews using the `/beans/` base prefix (for example: `/beans/log/<slug>`).
+- When a user requests changes, load `AGENTS.md` first and provide a preview in ChatGPT Codex.
 - Follow existing project conventions and patterns; mirror nearby code style when editing files.
 - Prefer small, focused changes that keep the CLI-inspired tone of the site intact.
 - Use the existing utilities (such as `withBase`) for building paths and links.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@ Beans is a CLI-inspired coffee log built with Astro. The site content lives in `
 ## General Guidelines
 
 - Always generate previews using the `/beans/` base prefix (for example: `/beans/log/<slug>`).
+- When a user requests changes, load `AGENTS.md` first and provide a preview in ChatGPT Codex.
 - Follow existing project conventions and patterns; mirror nearby code style when editing files.
 - Prefer small, focused changes that keep the CLI-inspired tone of the site intact.
 - Use the existing utilities (such as `withBase`) for building paths and links.


### PR DESCRIPTION
### Motivation

- Ensure instruction sets recommend loading `AGENTS.md` and showing a ChatGPT Codex preview whenever change requests are handled. 
- Keep RuleSync-managed guidance and agent/editor instruction files consistent with the project's preview workflow.

### Description

- Added the line "When a user requests changes, load `AGENTS.md` first and provide a preview in ChatGPT Codex." to `.rulesync/rules/overview.md`. 
- Propagated the same guidance to `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, and the generated editor output `.cursor/rules/overview.mdc`. 
- Regenerated RuleSync outputs with the RuleSync tool so the instruction artifacts were updated accordingly.

### Testing

- Ran `npx rulesync generate` and it completed successfully, reporting generated rule files. 
- The regenerated instruction files were produced as expected and no RuleSync errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a8fa20f6c8320984601211d4388ce)